### PR TITLE
Swift version required in Podspec

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.vanethos.notification_permissions'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.2.71'
+    ext.kotlin_version = '1.3.21'
     repositories {
         google()
         jcenter()

--- a/ios/notification_permissions.podspec
+++ b/ios/notification_permissions.podspec
@@ -15,6 +15,7 @@ A plugin to check and ask for notification permissions
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
+  s.swift_version    = '4.2'
 
   s.ios.deployment_target = '8.0'
 end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: notification_permissions
 description: A plugin to check and ask for notification permissions on Android and iOS
-version: 0.2.1
+version: 0.2.2
 author: Gonçalo Palma <solid.goncalo@gmail.com>
 homepage: https://github.com/Vanethos/flutter_notification_permissions/
 issue_tracker: https://github.com/Vanethos/flutter_notification_permissions/issues


### PR DESCRIPTION
There is an error when trying to run a Flutter application with mixed Objective-C and Swift plugins if there is no Swift Version specified in the podspec file.