### PR TITLE
Wait possibility for requestNotificationPermissions

### DIFF
--- a/android/src/main/java/com/vanethos/notification_permissions/NotificationPermissionsPlugin.java
+++ b/android/src/main/java/com/vanethos/notification_permissions/NotificationPermissionsPlugin.java
@@ -28,21 +28,21 @@ public class NotificationPermissionsPlugin implements MethodChannel.MethodCallHa
     this.context = registrar.activity();
   }
 
-
-
-    @Override
+  @Override
   public void onMethodCall(MethodCall call, MethodChannel.Result result) {
     if ("getNotificationPermissionStatus".equalsIgnoreCase(call.method)) {
       result.success(getNotificationPermissionStatus());
     } else if ("requestNotificationPermissions".equalsIgnoreCase(call.method)) {
       if (PERMISSION_DENIED.equalsIgnoreCase(getNotificationPermissionStatus())) {
         if (context instanceof Activity) {
-          final Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
           final Uri uri = Uri.fromParts("package", context.getPackageName(), null);
 
+          final Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
           intent.setData(uri);
 
           context.startActivity(intent);
+
+          result.success(null);
         } else {
           result.error(call.method, "context is not instance of Activity", null);
         }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: notification_permissions
 description: A plugin to check and ask for notification permissions on Android and iOS
-version: 0.4.1
+version: 0.4.2
 author: Gonçalo Palma <solid.goncalo@gmail.com>
 homepage: https://github.com/Vanethos/flutter_notification_permissions/
 issue_tracker: https://github.com/Vanethos/flutter_notification_permissions/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: notification_permissions
 description: A plugin to check and ask for notification permissions on Android and iOS
-version: 0.4.0
+version: 0.4.1
 author: Gonçalo Palma <solid.goncalo@gmail.com>
 homepage: https://github.com/Vanethos/flutter_notification_permissions/
 issue_tracker: https://github.com/Vanethos/flutter_notification_permissions/issues


### PR DESCRIPTION
* fix missing result() call for Android when PERMISSION_DENIED
* adding possibility for iOS 10.0 to wait for call requestNotificationPermissions (iOS permission dialog)

<pre>
await NotificationPermissions.requestNotificationPermissions(
  const NotificationSettingsIos(sound: true, badge: true, alert: true)
);
</pre>

_note: calling requestNotificationPermissions() will not return permission status (same as current version)_