### PR TITLE
Wait possibility for requestPermission method with status returned, 'openSettings' flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,14 @@ In iOS, a permission is `unknown` when the user hasn’t accepted or refuse the 
 ## Requesting Notification Permissions
 If the `PermissionStatus` is `denied` or `unknown`, we can ask the user for the Permissions:
 ```dart
-Future<PermissionStatus> permissionStatus = NotificationPermissions.getNotificationPermissionStatus();
+Future<PermissionStatus> permissionStatus = NotificationPermissions.getNotificationPermissionStatus({NotificationSettingsIos iosSettings, bool openSettings});
 ```
 
 On Android, if the permission is `denied`, this method will open the app settings.
 
 In iOS, if the permission is `unknown`, it will show an alert window asking the user for the permission. On the other hand, if the permission is `denied` it has the same behaviour as Android, opening the app settings.
+Also in iOS if you set `openSettings` to false settings window won't be opened. You will get `denied` status. 
+`NotificationPermissions.getNotificationPermissionStatus` returns status after user select answer from native permission popup.
 
 Note: if the permission is `granted`, this method will not do anything.
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -41,7 +41,8 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
 
   /// Checks the notification permission status
   Future<String> getCheckNotificationPermStatus() {
-    return NotificationPermissions.getNotificationPermissionStatus().then((status) {
+    return NotificationPermissions.getNotificationPermissionStatus()
+        .then((status) {
       switch (status) {
         case PermissionStatus.denied:
           return permDenied;
@@ -49,6 +50,8 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
           return permGranted;
         case PermissionStatus.unknown:
           return permUnknown;
+        default:
+          return null;
       }
     });
   }
@@ -92,13 +95,17 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
                       ),
                       FlatButton(
                         color: Colors.amber,
-                        child: Text("Ask for notification status".toUpperCase()),
+                        child:
+                            Text("Ask for notification status".toUpperCase()),
                         onPressed: () {
                           // show the dialog/open settings screen
                           NotificationPermissions
-                              .requestNotificationPermissions(
-                                  const NotificationSettingsIos(
-                                      sound: true, badge: true, alert: true))
+                                  .requestNotificationPermissions(
+                                      iosSettings:
+                                          const NotificationSettingsIos(
+                                              sound: true,
+                                              badge: true,
+                                              alert: true))
                               .then((_) {
                             // when finished, check the permission status
                             setState(() {

--- a/ios/Classes/SwiftNotificationPermissionsPlugin.swift
+++ b/ios/Classes/SwiftNotificationPermissionsPlugin.swift
@@ -20,7 +20,17 @@ public class SwiftNotificationPermissionsPlugin: NSObject, FlutterPlugin {
               if (status == self.permissionUnknown) {
 				  if #available(iOS 10.0, *) {
 					  let center = UNUserNotificationCenter.current()
-					  center.requestAuthorization(options: [.alert, .badge, .sound]) { (success, error) in
+					  var options = UNAuthorizationOptions()
+					  if(arguments["sound"] != nil){
+					  	options.insert(.sound)
+					  }
+					  if(arguments["alert"] != nil){
+						options.insert(.alert)
+					  }
+					  if(arguments["badge"] != nil){
+						options.insert(.badge)
+					  }
+					  center.requestAuthorization(options: options) { (success, error) in
 						  if error == nil {
 							  if success == true {
 								  result(self.permissionGranted)

--- a/ios/Classes/SwiftNotificationPermissionsPlugin.swift
+++ b/ios/Classes/SwiftNotificationPermissionsPlugin.swift
@@ -21,14 +21,16 @@ public class SwiftNotificationPermissionsPlugin: NSObject, FlutterPlugin {
 				  if #available(iOS 10.0, *) {
 					  let center = UNUserNotificationCenter.current()
 					  var options = UNAuthorizationOptions()
-					  if(arguments["sound"] != nil){
-					  	options.insert(.sound)
-					  }
-					  if(arguments["alert"] != nil){
-						options.insert(.alert)
-					  }
-					  if(arguments["badge"] != nil){
-						options.insert(.badge)
+					  if let arguments = call.arguments as? Dictionary<String, Bool> {
+						  if(arguments["sound"] != nil){
+							options.insert(.sound)
+						  }
+						  if(arguments["alert"] != nil){
+							options.insert(.alert)
+						  }
+						  if(arguments["badge"] != nil){
+							options.insert(.badge)
+						  }
 					  }
 					  center.requestAuthorization(options: options) { (success, error) in
 						  if error == nil {

--- a/lib/notification_permissions.dart
+++ b/lib/notification_permissions.dart
@@ -5,17 +5,20 @@ import 'package:meta/meta.dart';
 
 class NotificationPermissions {
   static const MethodChannel _channel =
-  const MethodChannel('notification_permissions');
+      const MethodChannel('notification_permissions');
 
-  static Future<void> requestNotificationPermissions(
-      [NotificationSettingsIos iosSettings = const NotificationSettingsIos()]) {
-    return _channel.invokeMethod(
-        'requestNotificationPermissions', iosSettings.toMap());
+  static Future<PermissionStatus> requestNotificationPermissions(
+      {NotificationSettingsIos iosSettings = const NotificationSettingsIos(),
+      bool openSettings = true}) async {
+    final map = iosSettings.toMap();
+    map["openSettings"] = openSettings;
+    String status = await _channel.invokeMethod('requestNotificationPermissions', map);
+    return _getPermissionStatus(status);
   }
 
   static Future<PermissionStatus> getNotificationPermissionStatus() async {
     final String status =
-    await _channel.invokeMethod('getNotificationPermissionStatus');
+        await _channel.invokeMethod('getNotificationPermissionStatus');
     return _getPermissionStatus(status);
   }
 


### PR DESCRIPTION
Hi, I just needed this lib to work the same way as other permission library. I have added proper `result` handling for request permission method. Right now it returns status from user action `granted` / `denied`. 

Also added possibility to configure if open system settings or not (before it opens it every time when `denied` was returned).

This is slightly upgraded version of other PR, that doesn't return status for request call.