### PR TITLE
Define CLANG, set version in .podspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.4.4
+* Corrected the path to the license file in .podspec
+* Define CLANG module, so that the plugin can be used statically
+* Ensure correct version is listed in .podspec
+
 # 0.4.3 
 * Added option to open settings or not in iOS when permition is denied [pawlowskim]
 * Adding possibility for iOS 10.0 to wait for call requestNotificationPermissions (iOS permission dialog) [kuzmisin]

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -33,7 +33,7 @@ def parse_KV_file(file, separator='=')
 end
 
 target 'Runner' do
-  use_frameworks!
+  # use_frameworks!
 
   # Prepare symlinks folder. We use symlinks to avoid having Podfile.lock
   # referring to absolute paths on developers' machines.

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -8,10 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
+		3A2D09386D434500AF4BC663 /* libPods-Runner.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A1F5874825554290F9BA23CC /* libPods-Runner.a */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		3B80C3941E831B6300D905FE /* App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; };
 		3B80C3951E831B6300D905FE /* App.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		5A2F73DB33A4AD1B2B27AC5C /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F9B9EC149E0CF1F92F4691B5 /* Pods_Runner.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
@@ -50,8 +50,8 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A1F5874825554290F9BA23CC /* libPods-Runner.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Runner.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C63D41A3830A36D56B57C8C4 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
-		F9B9EC149E0CF1F92F4691B5 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -60,7 +60,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3B80C3941E831B6300D905FE /* App.framework in Frameworks */,
-				5A2F73DB33A4AD1B2B27AC5C /* Pods_Runner.framework in Frameworks */,
+				3A2D09386D434500AF4BC663 /* libPods-Runner.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -80,7 +80,7 @@
 		8F93153BDE0FE52DBE7750DB /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				F9B9EC149E0CF1F92F4691B5 /* Pods_Runner.framework */,
+				A1F5874825554290F9BA23CC /* libPods-Runner.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -272,12 +272,10 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
 				"${PODS_ROOT}/../.symlinks/flutter/ios/Flutter.framework",
-				"${BUILT_PRODUCTS_DIR}/notification_permissions/notification_permissions.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Flutter.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/notification_permissions.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/example/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/example/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -4,5 +4,7 @@
 <dict>
 	<key>BuildSystemType</key>
 	<string>Latest</string>
+	<key>PreviewsEnabled</key>
+	<false/>
 </dict>
 </plist>

--- a/ios/Classes/NotificationPermissionsPlugin.m
+++ b/ios/Classes/NotificationPermissionsPlugin.m
@@ -1,5 +1,10 @@
 #import "NotificationPermissionsPlugin.h"
+
+#if __has_include(<notification_permissions/notification_permissions-Swift.h>)
 #import <notification_permissions/notification_permissions-Swift.h>
+#else
+#import "notification_permissions-Swift.h"
+#endif
 
 @implementation NotificationPermissionsPlugin
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {

--- a/ios/notification_permissions.podspec
+++ b/ios/notification_permissions.podspec
@@ -17,6 +17,8 @@ A plugin to check and ask for notification permissions
   s.dependency 'Flutter'
   s.swift_version    = '5.0'
 
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
+
   s.ios.deployment_target = '8.0'
 end
 

--- a/ios/notification_permissions.podspec
+++ b/ios/notification_permissions.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
 A plugin to check and ask for notification permissions
                        DESC
   s.homepage         = 'http://example.com'
-  s.license          = { :file => '../LICENSE' }
+  s.license          = { :file => '../LICENSE.md' }
   s.author           = { 'Your Company' => 'email@example.com' }
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'

--- a/ios/notification_permissions.podspec
+++ b/ios/notification_permissions.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'notification_permissions'
-  s.version          = '0.0.1'
+  s.version          = '0.4.4'
   s.summary          = 'A plugin to check and ask for notification permissions'
   s.description      = <<-DESC
 A plugin to check and ask for notification permissions

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: notification_permissions
 description: A plugin to check and ask for notification permissions on Android and iOS
-version: 0.4.3
+version: 0.4.4
 author: Gonçalo Palma <solid.goncalo@gmail.com>
 homepage: https://github.com/Vanethos/flutter_notification_permissions/
 issue_tracker: https://github.com/Vanethos/flutter_notification_permissions/issues


### PR DESCRIPTION
Various cleanups and allow the plugin to define the clang module, so that it can be loaded statically.

See discussions in Flutter https://github.com/flutter/flutter/issues/41007

This also fixed the podspec to show the correct version and link the LICENSE file properly:
```
[!] Unable to read the license file `../LICENSE` for the spec `notification_permissions (0.0.1)`
```