### PR TITLE
FIX: Android background permission check does not work.

### DIFF
--- a/android/src/main/java/com/vanethos/notification_permissions/NotificationPermissionsPlugin.java
+++ b/android/src/main/java/com/vanethos/notification_permissions/NotificationPermissionsPlugin.java
@@ -6,9 +6,9 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
 import android.provider.Settings;
-import android.util.Log;
 
 import androidx.core.app.NotificationManagerCompat;
+
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
@@ -24,9 +24,11 @@ public class NotificationPermissionsPlugin implements MethodChannel.MethodCallHa
   private static final String PERMISSION_DENIED = "denied";
 
   private final Context context;
+  private final Activity activity;
 
   private NotificationPermissionsPlugin(Registrar registrar) {
-    this.context = registrar.activity();
+    this.context = registrar.context();
+    this.activity = registrar.activity();
   }
 
   @Override
@@ -35,30 +37,31 @@ public class NotificationPermissionsPlugin implements MethodChannel.MethodCallHa
       result.success(getNotificationPermissionStatus());
     } else if ("requestNotificationPermissions".equalsIgnoreCase(call.method)) {
       if (PERMISSION_DENIED.equalsIgnoreCase(getNotificationPermissionStatus())) {
-        if (context instanceof Activity) {
-          // https://stackoverflow.com/a/45192258
-          final Intent intent = new Intent();
-
-          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-          // ACTION_APP_NOTIFICATION_SETTINGS was introduced in API level 26 aka Android O
-            intent.setAction(Settings.ACTION_APP_NOTIFICATION_SETTINGS);
-            intent.putExtra(Settings.EXTRA_APP_PACKAGE, context.getPackageName());
-          } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP){
-            intent.setAction("android.settings.APP_NOTIFICATION_SETTINGS");
-            intent.putExtra("app_package", context.getPackageName());
-            intent.putExtra("app_uid", context.getApplicationInfo().uid);
-          } else {
-            intent.setAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
-            intent.addCategory(Intent.CATEGORY_DEFAULT);
-            intent.setData(Uri.parse("package:" + context.getPackageName()));
-          }
-
-          context.startActivity(intent);
-
-          result.success(PERMISSION_DENIED);
-        } else {
-          result.error(call.method, "context is not instance of Activity", null);
+        if (activity == null) {
+          result.error(call.method, "activity is null", null);
+          return;
         }
+
+        // https://stackoverflow.com/a/45192258
+        final Intent intent = new Intent();
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+          // ACTION_APP_NOTIFICATION_SETTINGS was introduced in API level 26 aka Android O
+          intent.setAction(Settings.ACTION_APP_NOTIFICATION_SETTINGS);
+          intent.putExtra(Settings.EXTRA_APP_PACKAGE, activity.getPackageName());
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP){
+          intent.setAction("android.settings.APP_NOTIFICATION_SETTINGS");
+          intent.putExtra("app_package", activity.getPackageName());
+          intent.putExtra("app_uid", activity.getApplicationInfo().uid);
+        } else {
+          intent.setAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+          intent.addCategory(Intent.CATEGORY_DEFAULT);
+          intent.setData(Uri.parse("package:" + activity.getPackageName()));
+        }
+
+        activity.startActivity(intent);
+
+        result.success(PERMISSION_DENIED);
       } else {
         result.success(PERMISSION_GRANTED);
       }


### PR DESCRIPTION
During background operations, the `Context` received with `Registrar.activity()` is null. This is also in the doc for `Registrar.activity()`.

The solution is to use an `Activity` (`Registrar.activity()`) for `requestNotificationPermissions`, which will only make sense in the foreground and use a `Context` (`Registrar.context()`) for `getNotificationPermissionStatus` which can also be used during background tasks, such as handling a (silent) push notification.