### PR TITLE
specify MIT license

### DIFF
--- a/ios/notification_permissions.podspec
+++ b/ios/notification_permissions.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
 A plugin to check and ask for notification permissions
                        DESC
   s.homepage         = 'http://example.com'
-  s.license          = { :file => '../LICENSE.md' }
+  s.license          = { :type => 'MIT' }
   s.author           = { 'Your Company' => 'email@example.com' }
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'


### PR DESCRIPTION
This avoids the warning:

```
Unable to read the license file `../LICENSE.md` for the spec
```

<img width="1363" alt="Screen Shot 2021-09-16 at 8 50 31 AM" src="https://user-images.githubusercontent.com/77690617/133615074-334ff57f-0c81-46a5-857e-04f3aa838445.png">
