### PR TITLE
Suppress deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.6.1
+
+* Suppresses Android deprecation warning [nohli]
+
 # 0.6.0
 
 * Supports Android V2 embedding [ened]

--- a/android/src/main/java/com/vanethos/notification_permissions/NotificationPermissionsPlugin.java
+++ b/android/src/main/java/com/vanethos/notification_permissions/NotificationPermissionsPlugin.java
@@ -9,10 +9,10 @@ import io.flutter.embedding.engine.plugins.activity.ActivityAware;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodChannel;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 public class NotificationPermissionsPlugin implements FlutterPlugin, ActivityAware {
-  public static void registerWith(Registrar registrar) {
+  @SuppressWarnings("deprecation")
+  public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
     final NotificationPermissionsPlugin plugin = new NotificationPermissionsPlugin();
     plugin.onAttachedToEngine(registrar.context(), registrar.messenger());
 

--- a/android/src/main/java/com/vanethos/notification_permissions/NotificationPermissionsPlugin.java
+++ b/android/src/main/java/com/vanethos/notification_permissions/NotificationPermissionsPlugin.java
@@ -21,9 +21,11 @@ public class NotificationPermissionsPlugin implements FlutterPlugin, ActivityAwa
     }
   }
 
-  @Nullable private MethodChannel channel;
+  @Nullable
+  private MethodChannel channel;
 
-  @Nullable private MethodCallHandlerImpl methodCallHandler;
+  @Nullable
+  private MethodCallHandlerImpl methodCallHandler;
 
   @Override
   public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.2
+  cupertino_icons: ^1.0.3
 
 dev_dependencies:
   flutter_test:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.1.12 <3.0.0"
+  sdk: '>=2.1.12 <3.0.0'
 
 dependencies:
   flutter:
@@ -26,23 +26,18 @@ dev_dependencies:
 
 # The following section is specific to Flutter.
 flutter:
-
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.
   uses-material-design: true
-
   # To add assets to your application, add an assets section, like this:
   # assets:
   #  - images/a_dot_burr.jpeg
   #  - images/a_dot_ham.jpeg
-
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.io/assets-and-images/#resolution-aware.
-
   # For details regarding adding assets from package dependencies, see
   # https://flutter.io/assets-and-images/#from-packages
-
   # To add custom fonts to your application, add a fonts section here,
   # in this "flutter" section. Each entry in this list should have a
   # "family" key with the font family name, and a "fonts" key with a

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: notification_permissions
 description: A plugin to check and ask for notification permissions on Android and iOS
-version: 0.6.0
+version: 0.6.1
 homepage: https://github.com/Vanethos/flutter_notification_permissions/
 issue_tracker: https://github.com/Vanethos/flutter_notification_permissions/issues
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
-  flutter: ">=1.12.0"
+  flutter: '>=1.12.0'
 
 dependencies:
   flutter:
@@ -22,5 +22,5 @@ flutter:
       android:
         package: com.vanethos.notification_permissions
         pluginClass: NotificationPermissionsPlugin
-      ios: 
+      ios:
         pluginClass: NotificationPermissionsPlugin


### PR DESCRIPTION
The plugin uses the deprecated registerWith() method to maintain backwards compatibility...
This results in a deprecation warning on each Android build, if it doesn't use `@SuppressWarnings("deprecation")`.
This PR fixes the warnings.