### PR TITLE
Add Android 13 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ If the `PermissionStatus` is `denied` or `unknown`, we can ask the user for the 
 Future<PermissionStatus> permissionStatus = NotificationPermissions.requestNotificationPermissions({NotificationSettingsIos iosSettings, bool openSettings});
 ```
 
-On Android, if the permission is `denied`, this method will open the app settings.
+On Android 12 and lower, if the permission is `denied`, this method will open the app settings.
+On Android 13 and higher system dialog asking for permission will be displayed. To be able to request permission on Android 13+ add the following permission to `AndroidManifest.xml`:
+```xml
+<uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+```
 
 In iOS, if the permission is `unknown` or `provisional`, it will show an alert window asking the user for the permission. On the other hand, if the permission is `denied` it has the same behaviour as Android, opening the app settings.
 Also in iOS if you set `openSettings` to false settings window won't be opened. You will get `denied` status. 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 16

--- a/android/src/main/java/com/vanethos/notification_permissions/MethodCallHandlerImpl.java
+++ b/android/src/main/java/com/vanethos/notification_permissions/MethodCallHandlerImpl.java
@@ -1,24 +1,36 @@
 package com.vanethos.notification_permissions;
 
+import android.Manifest;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Build;
 import android.provider.Settings;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.app.NotificationManagerCompat;
+
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
+import io.flutter.plugin.common.PluginRegistry;
 
-public class MethodCallHandlerImpl implements MethodCallHandler {
+public class MethodCallHandlerImpl implements MethodCallHandler, PluginRegistry.RequestPermissionsResultListener {
   private static final String PERMISSION_GRANTED = "granted";
   private static final String PERMISSION_DENIED = "denied";
 
+  private static final int REQUEST_CODE = MethodCallHandlerImpl.class.hashCode();
+
   private final Context applicationContext;
-  @Nullable private Activity activity;
+
+  @Nullable
+  private Activity activity;
+
+  @Nullable
+  private MethodChannel.Result permissionRequestResult;
 
   public MethodCallHandlerImpl(Context applicationContext) {
     this.applicationContext = applicationContext;
@@ -26,6 +38,7 @@ public class MethodCallHandlerImpl implements MethodCallHandler {
 
   public void setActivity(@Nullable Activity activity) {
     this.activity = activity;
+    this.permissionRequestResult = null;
   }
 
   @Override
@@ -38,6 +51,13 @@ public class MethodCallHandlerImpl implements MethodCallHandler {
 
         if (activity == null) {
           result.error(call.method, "context is not instance of Activity", null);
+          return;
+        }
+
+        // Since TIRAMISU (API level 33) POST_NOTIFICATIONS permission can be requested
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+          permissionRequestResult = result;
+          activity.requestPermissions(new String[]{Manifest.permission.POST_NOTIFICATIONS}, REQUEST_CODE);
           return;
         }
 
@@ -69,9 +89,26 @@ public class MethodCallHandlerImpl implements MethodCallHandler {
     }
   }
 
+  @Override
+  public boolean onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+    if (requestCode != REQUEST_CODE || permissions.length == 0) {
+      return false;
+    }
+
+    if (permissionRequestResult != null) {
+      permissionRequestResult.success(
+              grantResults[0] == PackageManager.PERMISSION_GRANTED
+                      ? PERMISSION_GRANTED
+                      : PERMISSION_DENIED
+      );
+    }
+
+    return true;
+  }
+
   private String getNotificationPermissionStatus() {
     return (NotificationManagerCompat.from(applicationContext).areNotificationsEnabled())
-        ? PERMISSION_GRANTED
-        : PERMISSION_DENIED;
+            ? PERMISSION_GRANTED
+            : PERMISSION_DENIED;
   }
 }

--- a/android/src/main/java/com/vanethos/notification_permissions/NotificationPermissionsPlugin.java
+++ b/android/src/main/java/com/vanethos/notification_permissions/NotificationPermissionsPlugin.java
@@ -2,8 +2,10 @@ package com.vanethos.notification_permissions;
 
 import android.app.Activity;
 import android.content.Context;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
@@ -27,6 +29,9 @@ public class NotificationPermissionsPlugin implements FlutterPlugin, ActivityAwa
   @Nullable
   private MethodCallHandlerImpl methodCallHandler;
 
+  @Nullable
+  ActivityPluginBinding activityPluginBinding;
+
   @Override
   public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
     onAttachedToEngine(binding.getApplicationContext(), binding.getBinaryMessenger());
@@ -48,7 +53,9 @@ public class NotificationPermissionsPlugin implements FlutterPlugin, ActivityAwa
 
   @Override
   public void onAttachedToActivity(@NonNull ActivityPluginBinding binding) {
+    activityPluginBinding = binding;
     onActivityChanged(binding.getActivity());
+    startListeningForPermissionResult();
   }
 
   @Override
@@ -64,11 +71,24 @@ public class NotificationPermissionsPlugin implements FlutterPlugin, ActivityAwa
   @Override
   public void onDetachedFromActivity() {
     onActivityChanged(null);
+    stopListeningForPermissionResult();
   }
 
   private void onActivityChanged(@Nullable Activity activity) {
     if (methodCallHandler != null) {
       methodCallHandler.setActivity(activity);
+    }
+  }
+
+  private void startListeningForPermissionResult() {
+    if (this.activityPluginBinding != null && methodCallHandler != null) {
+      activityPluginBinding.addRequestPermissionsResultListener(methodCallHandler);
+    }
+  }
+
+  private void stopListeningForPermissionResult() {
+    if (this.activityPluginBinding != null && methodCallHandler != null) {
+      activityPluginBinding.removeRequestPermissionsResultListener(methodCallHandler);
     }
   }
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -45,7 +45,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.example"
         minSdkVersion 16
-        targetSdkVersion 30
+        targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,10 +1,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.example">
+
+   <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+
    <application
         android:label="example"
         android:icon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"
+            android:exported="true"
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.7.10'
     repositories {
         google()
         jcenter()

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip


### PR DESCRIPTION
This PR adds support for a new Android 13 `POST_NOTIFICATION` permission that can be requested via the native `requestPermissions` method.